### PR TITLE
Fix KeyError when no data for a path

### DIFF
--- a/cyanite.py
+++ b/cyanite.py
@@ -46,7 +46,7 @@ class CyaniteReader(object):
         if 'error' in data:
             return (start_time, end_time, end_time - start_time), []
         time_info = data['from'], data['to'], data['step']
-        return time_info, data['series'][self.path]
+        return time_info, data['series'].get(self.path, [])
 
     def get_intervals(self):
         # TODO use cyanite info


### PR DESCRIPTION
I was getting a KeyError on a path when no data was available, this fixes that by return an array by default if they key doesn't exist
