### PR TITLE
adding in compatibility to work with disthene-reader

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,11 +75,13 @@ Optional config settings
 Additional settings are available for the maximum ``urllenth`` and setting a
 ``tenant`` value for compatibiliy with the `disthene-reader`_ project.
 
+.. _disthene-reader: https://github.com/EinsamHauer/disthene-reader
+
     # Graphite-API
     cyanite:
       urllength: 4096
       tenant: 'None'
-    
+
     # Graphite-web
     CYANITE_URLLENGTH = (
         '4096'
@@ -87,8 +89,6 @@ Additional settings are available for the maximum ``urllenth`` and setting a
     TENANT = (
         'None'
     )
-
-.. _disthene-reader: https://github.com/EinsamHauer/disthene-reader
 
 Changelog
 ---------

--- a/README.rst
+++ b/README.rst
@@ -69,6 +69,27 @@ See `pyr/cyanite`_ for running the Cyanite carbon daemon.
 
 .. _pyr/cyanite: https://github.com/pyr/cyanite
 
+Optional config settings
+------------------------
+
+Additional settings are available for the maximum ``urllenth`` and setting a
+``tenant`` value for compatibiliy with the `disthene-reader`_ project.
+
+    # Graphite-API
+    cyanite:
+      urllength: 4096
+      tenant: 'None'
+    
+    # Graphite-web
+    CYANITE_URLLENGTH = (
+        '4096'
+    )
+    TENANT = (
+        'None'
+    )
+
+.. _disthene-reader: https://github.com/EinsamHauer/disthene-reader
+
 Changelog
 ---------
 


### PR DESCRIPTION
Adds default variables for the ability to use this finder with the disthene-reader project. 

After much time working to get cyanite running well along with graphite-api, it was apparent that the poor performance of the cyanite processes interaction with the metric path index being stored within cassandra was not going to be feasible for our environment (due to volume and variety of metric name spaces, the jvm spent all its time in cpu regardless of heap sizing).

This started us looking towards the disthene project, and since it supported the use of elasticsearch (as did cyanite prior to 0.5.1 iirc) this proved to be very quick and fit our use case.

However disthene additionally has a notion of multi tenancy, and to support being able to query its mostly cyanite compatible api, i've added this value to the graphite-cyanite finder with some sane defaults that should ensure compatibility.