### PR TITLE
Adopt recent cyanite API changes.

### DIFF
--- a/cyanite.py
+++ b/cyanite.py
@@ -100,10 +100,10 @@ class CyaniteFinder(object):
                              params={'query': query.pattern}).json()
         for path in paths:
             if path['leaf']:
-                yield CyaniteLeafNode(path['path'],
-                                      CyaniteReader(path['path']))
+                yield CyaniteLeafNode(path['id'],
+                                      CyaniteReader(path['id']))
             else:
-                yield BranchNode(path['path'])
+                yield BranchNode(path['id'])
 
     def fetch_multi(self, nodes, start_time, end_time):
 

--- a/tests.py
+++ b/tests.py
@@ -18,9 +18,9 @@ class CyaniteTests(TestCase):
     @patch('requests.get')
     def test_metrics(self, get):
         get.return_value.json.return_value = [
-            {'path': 'foo.',
+            {'id': 'foo.',
              'leaf': 0},
-            {'path': 'foo.bar',
+            {'id': 'foo.bar',
              'leaf': 1},
         ]
         finder = CyaniteFinder({'cyanite': {'url': 'http://host:8080'}})
@@ -51,9 +51,9 @@ class CyaniteTests(TestCase):
     @patch('requests.get')
     def test_fetch_multi(self, get):
         get.return_value.json.return_value = [
-            {'path': 'foo.baz',
+            {'id': 'foo.baz',
              'leaf': 1},
-            {'path': 'foo.bar',
+            {'id': 'foo.bar',
              'leaf': 1},
         ]
 


### PR DESCRIPTION
The cyanite HTTP API returns a slightly modified datastructure in recent versions.
The dictionary key "path" seems to be renamed to "id".