### PR TITLE
Get proper one leaf node instead of getting all of them

### DIFF
--- a/cyanite.py
+++ b/cyanite.py
@@ -100,8 +100,9 @@ class CyaniteFinder(object):
                              params={'query': query.pattern}).json()
         for path in paths:
             if path['leaf']:
-                yield CyaniteLeafNode(path['path'],
-                                      CyaniteReader(path['path']))
+                if path['id'] == path['path']:
+                    yield CyaniteLeafNode(
+                        path['path'], CyaniteReader(path['path']))
             else:
                 yield BranchNode(path['path'])
 


### PR DESCRIPTION
This is because Cyanite API adds additional metric data like: max, min, sum and mean. You can access them by adding appropriate suffix to metric name, e.g. "my.sample.metric_mean". By default graphite-cyanite gets last of them which is "sum".

`http://cyanite.localdomain/paths?query=my.sample.metric`

returns:
```
[

    {
        "text": "metric",
        "id": "my.sample.metric",
        "path": "my.sample.metric",
        "allowChildren": false,
        "expandable": false,
        "leaf": true
    },
    {
        "text": "metric_min",
        "id": "my.sample.metric",
        "path": "my.sample.metric_min",
        "allowChildren": false,
        "expandable": false,
        "leaf": true
    },
    {
        "text": "metric_max",
        "id": "my.sample.metric",
        "path": "my.sample.metric_max",
        "allowChildren": false,
        "expandable": false,
        "leaf": true
    },
    {
        "text": "metric_mean",
        "id": "my.sample.metric",
        "path": "my.sample.metric_mean",
        "allowChildren": false,
        "expandable": false,
        "leaf": true
    },
    {
        "text": "metric_sum",
        "id": "my.sample.metric",
        "path": "my.sample.metric_sum",
        "allowChildren": false,
        "expandable": false,
        "leaf": true
    }

]
```

So graphite-cyanite is accessing "my.sample.metric_sum".